### PR TITLE
ビルドエラー修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/config.yaml
+++ b/config.yaml
@@ -32,7 +32,7 @@ siteStream:
     primary: false
   entityId: site-entity
 sitemap:
-  exclude_list:
+  excludeList:
     - feedback/
     - robots.txt
     - google5804978b12580bf0.html


### PR DESCRIPTION
1. config.yamlのsitemap.exclude_listをsitemap.excludeListに修正（キャメルケース形式に変更）\n2. .envファイルを作成してGoogle Maps APIキー（YEXT_PUBLIC_MAPS_API_KEY）を設定\n3. .gitignoreに.envを追加して機密情報の漏洩を防止\n\nこれらの変更によりビルドエラーが解消されます。