### PR TITLE
fix: getPath関数にフォールバック処理を追加

### DIFF
--- a/src/layouts/city/getPath.tsx
+++ b/src/layouts/city/getPath.tsx
@@ -10,5 +10,11 @@ import type { DirectoryProfile, TemplateProps } from "src/types/entities";
 export const getPath: GetPath<TemplateProps<DirectoryProfile<never>>> = (
   data
 ) => {
-  return data.document.slug;
+  // slugが存在する場合はそれを使用
+  if (data.document.slug) {
+    return data.document.slug;
+  }
+  
+  // slugが存在しない場合はIDを文字列化してパスにする
+  return `city-${data.document.id}`;
 };

--- a/src/layouts/entity/getPath.tsx
+++ b/src/layouts/entity/getPath.tsx
@@ -9,5 +9,12 @@ import type { TemplateProps } from "src/types/entities";
  * take on the form: featureName/entityId
  */
 export const getPath: GetPath<TemplateProps<LocationProfile>> = (data) => {
-  return data.document.slug;
+  // slugが存在する場合はそれを使用
+  if (data.document.slug) {
+    return data.document.slug;
+  }
+  
+  // slugが存在しない場合はIDを文字列化してパスにする
+  // または他のフィールドを組み合わせてパスを生成
+  return `location-${data.document.id}`;
 };

--- a/src/layouts/region/getPath.tsx
+++ b/src/layouts/region/getPath.tsx
@@ -10,5 +10,11 @@ import type { DirectoryProfile, TemplateProps } from "src/types/entities";
 export const getPath: GetPath<TemplateProps<DirectoryProfile<never>>> = (
   data
 ) => {
-  return data.document.slug;
+  // slugが存在する場合はそれを使用
+  if (data.document.slug) {
+    return data.document.slug;
+  }
+  
+  // slugが存在しない場合はIDを文字列化してパスにする
+  return `region-${data.document.id}`;
 };

--- a/src/layouts/root/getPath.tsx
+++ b/src/layouts/root/getPath.tsx
@@ -10,5 +10,11 @@ import type { DirectoryProfile, TemplateProps } from "src/types/entities";
 export const getPath: GetPath<TemplateProps<DirectoryProfile<never>>> = (
   data
 ) => {
-  return data.document.slug;
+  // slugが存在する場合はそれを使用
+  if (data.document.slug) {
+    return data.document.slug;
+  }
+  
+  // slugが存在しない場合はIDを文字列化してパスにする
+  return `directory-${data.document.id}`;
 };


### PR DESCRIPTION
## 問題

Yextのビルド時に以下のエラーが発生しています：
`
Failed to generate page for feature entity using entity 1055837314 with locale ja, in stream locations-v36nik52pf, due to the following error: getPath does not return a valid string in template 'entity'
`

## 原因分析

dm_directoryParentsフィールドの削除により、ページURLパスの生成に問題が発生しています。現在の実装では、getPath関数は単純にdata.document.slugを返していますが、このフィールドが有効な文字列でない場合にエラーが発生します。

## 修正内容

各テンプレート（entity、city、region、root）のgetPath関数に、slugフィールドが欠損または無効な場合のフォールバック処理を追加しました：

1. 有効なslugフィールドがある場合はそのまま使用
2. ない場合はドキュメントIDを使用して一意のパスを生成

## 変更したファイル
- src/layouts/entity/getPath.tsx
- src/layouts/city/getPath.tsx
- src/layouts/region/getPath.tsx
- src/layouts/root/getPath.tsx

この修正により、getPath does not return a valid stringエラーが解消され、ページ生成が正常に完了することが期待されます。