### PR TITLE
fix: テンプレート形式のslugに対応するよう改善

### DIFF
--- a/src/layouts/city/getPath.tsx
+++ b/src/layouts/city/getPath.tsx
@@ -10,11 +10,16 @@ import type { DirectoryProfile, TemplateProps } from "src/types/entities";
 export const getPath: GetPath<TemplateProps<DirectoryProfile<never>>> = (
   data
 ) => {
-  // slugが存在する場合はそれを使用
-  if (data.document.slug) {
+  // slugが存在し、かつテンプレート形式（[[...]]）でない場合はそれを使用
+  if (data.document.slug && !data.document.slug.includes("[[")) {
     return data.document.slug;
   }
   
-  // slugが存在しない場合はIDを文字列化してパスにする
-  return `city-${data.document.id}`;
+  // slugがない場合やテンプレート形式の場合、ID + 名前を使用してパスを生成
+  let slugifiedName = "";
+  if (data.document.name) {
+    slugifiedName = `-${data.document.name.toLowerCase().replace(/[^\w\s]/g, "").replace(/\s+/g, "-")}`;
+  }
+  
+  return `city-${data.document.id}${slugifiedName}`;
 };

--- a/src/layouts/entity/getPath.tsx
+++ b/src/layouts/entity/getPath.tsx
@@ -9,12 +9,17 @@ import type { TemplateProps } from "src/types/entities";
  * take on the form: featureName/entityId
  */
 export const getPath: GetPath<TemplateProps<LocationProfile>> = (data) => {
-  // slugが存在する場合はそれを使用
-  if (data.document.slug) {
+  // slugが存在し、かつテンプレート形式（[[...]]）でない場合はそれを使用
+  if (data.document.slug && !data.document.slug.includes("[[")) {
     return data.document.slug;
   }
   
-  // slugが存在しない場合はIDを文字列化してパスにする
-  // または他のフィールドを組み合わせてパスを生成
-  return `location-${data.document.id}`;
+  // slugがない場合やテンプレート形式の場合、ID + 名前を使用してパスを生成
+  // 名前がある場合はスラッグ化して使用（空白をハイフンに、特殊文字を削除）
+  let slugifiedName = "";
+  if (data.document.name) {
+    slugifiedName = `-${data.document.name.toLowerCase().replace(/[^\w\s]/g, "").replace(/\s+/g, "-")}`;
+  }
+  
+  return `location-${data.document.id}${slugifiedName}`;
 };

--- a/src/layouts/region/getPath.tsx
+++ b/src/layouts/region/getPath.tsx
@@ -10,11 +10,16 @@ import type { DirectoryProfile, TemplateProps } from "src/types/entities";
 export const getPath: GetPath<TemplateProps<DirectoryProfile<never>>> = (
   data
 ) => {
-  // slugが存在する場合はそれを使用
-  if (data.document.slug) {
+  // slugが存在し、かつテンプレート形式（[[...]]）でない場合はそれを使用
+  if (data.document.slug && !data.document.slug.includes("[[")) {
     return data.document.slug;
   }
   
-  // slugが存在しない場合はIDを文字列化してパスにする
-  return `region-${data.document.id}`;
+  // slugがない場合やテンプレート形式の場合、ID + 名前を使用してパスを生成
+  let slugifiedName = "";
+  if (data.document.name) {
+    slugifiedName = `-${data.document.name.toLowerCase().replace(/[^\w\s]/g, "").replace(/\s+/g, "-")}`;
+  }
+  
+  return `region-${data.document.id}${slugifiedName}`;
 };

--- a/src/layouts/root/getPath.tsx
+++ b/src/layouts/root/getPath.tsx
@@ -10,11 +10,16 @@ import type { DirectoryProfile, TemplateProps } from "src/types/entities";
 export const getPath: GetPath<TemplateProps<DirectoryProfile<never>>> = (
   data
 ) => {
-  // slugが存在する場合はそれを使用
-  if (data.document.slug) {
+  // slugが存在し、かつテンプレート形式（[[...]]）でない場合はそれを使用
+  if (data.document.slug && !data.document.slug.includes("[[")) {
     return data.document.slug;
   }
   
-  // slugが存在しない場合はIDを文字列化してパスにする
-  return `directory-${data.document.id}`;
+  // slugがない場合やテンプレート形式の場合、ID + 名前を使用してパスを生成
+  let slugifiedName = "";
+  if (data.document.name) {
+    slugifiedName = `-${data.document.name.toLowerCase().replace(/[^\w\s]/g, "").replace(/\s+/g, "-")}`;
+  }
+  
+  return `directory-${data.document.id}${slugifiedName}`;
 };


### PR DESCRIPTION
## 問題

エンティティID 406180（タイプ: location）が正しく表示されない問題があります。

## 原因分析

詳細な調査の結果、以下の問題を発見しました：

1. スラグフィールドがテンプレート形式（[[address.region]]/[[address.city]]/[[address.line1]]など）で設定されているエンティティが存在する
2. このテンプレート形式のスラグが正しく展開されていない可能性がある
3. 以前の修正では単純にslugフィールドの有無のみを確認していたが、テンプレート形式のスラグは無効な値として扱う必要がある

## 修正内容

各テンプレート（entity、city、region、root）のgetPath関数を強化して以下の機能を追加しました：

1. スラグがテンプレート形式（[[...]]を含む）かどうかを確認するチェック
2. テンプレート形式のスラグを無効として扱い、フォールバック処理を実行
3. フォールバック処理の改善：エンティティの名前も利用してより意味のあるURLを生成
   - 名前をスラッグ化（小文字化、特殊文字削除、スペースをハイフンに変換）
   - ID + 名前の組み合わせでユニークなパスを生成（例：location-406180-xxx-sendai-izumi-eigyosho）

## 期待される結果

この修正により、テンプレート形式のスラグを持つエンティティも含めて、すべてのエンティティが正しく表示されるようになります。特にエンティティID 406180についても、有効なパスが生成され表示されるようになります。